### PR TITLE
evcc YAML Template for SMARTFOX Pro (Firmware Version EM2 00.01.07.03)

### DIFF
--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -22,10 +22,10 @@ render: |
   type: custom
   # jq: parse json generated from response values.xml (https://jqplay.org is your friend to test queries)
   {{- if not .usage }}
-  power:
-    source: http
+  power: # heating power in W
     uri: {{ include "uri" . }}
-    jq: .power_sf
+    jq: .values.value[] | select(.attrid=="htPowerMeasValue")."#content" | rtrimstr(" kW")
+    scale: 1000
   {{- end }}
   {{- if eq .usage "grid" }}
   power: # grid power in W

--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -20,6 +20,7 @@ render: |
   http://{{ .host }}/values.xml
   {{- end }}
   type: custom
+  # jq: parse json generated from response values.xml (https://jqplay.org is your friend to test queries)
   {{- if not .usage }}
   power:
     source: http
@@ -30,7 +31,7 @@ render: |
   power:
     source: http
     uri: {{ include "uri" . }}
-    jq: .power_io
+    jq: .values.value[] | select(.attrid=="detailsPowerValue")."#content" | rtrimstr(" W")
   energy:
     source: http
     uri: {{ include "uri" . }}

--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -1,0 +1,80 @@
+template: smartfox
+products:
+  - brand: Smartfox
+    description:
+      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light, Reg, Reg extended
+requirements:
+  description:
+    de: |
+      Kann verwendet werden, um Daten für `grid`, `pv` und `aux` zu erhalten. 
+      Wenn `usage` nicht definiert ist, wird die Leistung für die Warmwasserbereitung zurückgegeben (als `aux` zu verwenden).
+    en: |
+      Can be used to get `grid`, `pv` and `aux` data. 
+      If `usage` is not defined, then return the power for the water heating (to be used as `aux`).
+params:
+  - name: usage
+    choice: ["grid", "pv"]
+  - name: host
+render: |
+  {{- define "uri" -}}
+  http://{{ .host }}/all
+  {{- end }}
+  type: custom
+  {{- if not .usage }}
+  power:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .power_sf
+  {{- end }}
+  {{- if eq .usage "grid" }}
+  power:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .power_io
+  energy:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .energy_in
+    scale: 0.001  
+  voltages:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .voltages[0]
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .voltages[1]
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .voltages[2]
+  currents:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .currents[0]
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .currents[1]
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .currents[2]
+  powers:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .powers[0]
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .powers[1]
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .powers[2]
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .PvPower[0]
+  energy:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .PvEnergy[0]
+    scale: 0.001
+  {{- end }}

--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -23,6 +23,7 @@ render: |
   # jq: parse json generated from response values.xml (https://jqplay.org is your friend to test queries)
   {{- if not .usage }}
   power: # heating power in W
+    source: http
     uri: {{ include "uri" . }}
     jq: .values.value[] | select(.attrid=="htPowerMeasValue")."#content" | rtrimstr(" kW")
     scale: 1000

--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -1,8 +1,8 @@
-template: smartfox
+template: smartfox-values
 products:
   - brand: Smartfox
     description:
-      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light, Reg, Reg extended
+      generic: Pro (Firmware Version EM2 00.01.07.03) - not tested on other SmartFox devices yet
 requirements:
   description:
     de: |

--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -17,7 +17,7 @@ params:
   - name: host
 render: |
   {{- define "uri" -}}
-  http://{{ .host }}/all
+  http://{{ .host }}/values.xml
   {{- end }}
   type: custom
   {{- if not .usage }}

--- a/templates/definition/meter/smartfox-values.yaml
+++ b/templates/definition/meter/smartfox-values.yaml
@@ -28,54 +28,85 @@ render: |
     jq: .power_sf
   {{- end }}
   {{- if eq .usage "grid" }}
-  power:
+  power: # grid power in W
     source: http
     uri: {{ include "uri" . }}
     jq: .values.value[] | select(.attrid=="detailsPowerValue")."#content" | rtrimstr(" W")
-  energy:
+  energy: # grid energy in kWh
     source: http
     uri: {{ include "uri" . }}
-    jq: .energy_in
-    scale: 0.001  
-  voltages:
+    jq: .values.value[] | select(.attrid=="energyValue")."#content" | rtrimstr(" kWh")
+  voltages: # grid voltages in V
   - source: http
     uri: {{ include "uri" . }}
-    jq: .voltages[0]
+    jq: .values.value[] | select(.attrid=="voltageL1Value")."#content" | rtrimstr(" V")
   - source: http
     uri: {{ include "uri" . }}
-    jq: .voltages[1]
+    jq: .values.value[] | select(.attrid=="voltageL2Value")."#content" | rtrimstr(" V")
   - source: http
     uri: {{ include "uri" . }}
-    jq: .voltages[2]
-  currents:
+    jq: .values.value[] | select(.attrid=="voltageL3Value")."#content" | rtrimstr(" V")
+  currents: # grid currents in A
   - source: http
     uri: {{ include "uri" . }}
-    jq: .currents[0]
+    jq: .values.value[] | select(.attrid=="ampereL1Value")."#content" | rtrimstr(" A")
   - source: http
     uri: {{ include "uri" . }}
-    jq: .currents[1]
+    jq: .values.value[] | select(.attrid=="ampereL2Value")."#content" | rtrimstr(" A")
   - source: http
     uri: {{ include "uri" . }}
-    jq: .currents[2]
-  powers:
+    jq: .values.value[] | select(.attrid=="ampereL3Value")."#content" | rtrimstr(" A")
+  powers: # grid powers in W
   - source: http
     uri: {{ include "uri" . }}
-    jq: .powers[0]
+    jq: .values.value[] | select(.attrid=="powerL1Value")."#content" | rtrimstr(" W")
   - source: http
     uri: {{ include "uri" . }}
-    jq: .powers[1]
+    jq: .values.value[] | select(.attrid=="powerL2Value")."#content" | rtrimstr(" W")
   - source: http
     uri: {{ include "uri" . }}
-    jq: .powers[2]
+    jq: .values.value[] | select(.attrid=="powerL3Value")."#content" | rtrimstr(" W")
   {{- end }}
   {{- if eq .usage "pv" }}
-  power:
-    source: http
-    uri: {{ include "uri" . }}
-    jq: .PvPower[0]
-  energy:
-    source: http
-    uri: {{ include "uri" . }}
-    jq: .PvEnergy[0]
-    scale: 0.001
+  power: # PV power in W
+    source: calc
+    add:
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr1PowerValue")."#content" | rtrimstr(" kW")
+      scale: 1000
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr2PowerValue")."#content" | rtrimstr(" kW")
+      scale: 1000
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr3PowerValue")."#content" | rtrimstr(" kW")
+      scale: 1000
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr4PowerValue")."#content" | rtrimstr(" kW")
+      scale: 1000
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr5PowerValue")."#content" | rtrimstr(" kW")
+      scale: 1000
+  energy: # PV energy in kWh
+    source: calc
+    add:
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr1EnergyValue")."#content" | rtrimstr(" kWh")
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr2EnergyValue")."#content" | rtrimstr(" kWh")
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr3EnergyValue")."#content" | rtrimstr(" kWh")
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr4EnergyValue")."#content" | rtrimstr(" kWh")
+    - source: http
+      uri: {{ include "uri" . }}
+      jq: .values.value[] | select(.attrid=="wr5EnergyValue")."#content" | rtrimstr(" kWh")
   {{- end }}


### PR DESCRIPTION
See https://github.com/evcc-io/evcc/issues/11318

Test output from `evcc meter` with my SMARTFOX Pro (Firmware Version EM2 00.01.07.03) at night (PV power = 0W):

smartfox-grid
-------------
Power:          6315W
Energy:         68864.2kWh
Current L1..L3: 15.7A 7.47A 6.35A
Voltage L1..L3: 225V 227V 225V
Power L1..L3:   3.47e+03W 1.48e+03W 1.37e+03W

smartfox-pv
-----------
Power:  0W
Energy: 63478.2kWh

smartfox-aux
------------
Power: 0W
